### PR TITLE
Add expandable descriptions and reason field

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,14 @@
       0% { transform: rotate(0deg); }
       100% { transform: rotate(360deg); }
     }
+
+    .desc.clamp {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      display: -webkit-box;
+      -webkit-line-clamp: 3;
+      -webkit-box-orient: vertical;
+    }
   </style>
 </head>
 <body class="bg-[#fcf8f8]" style='font-family:"Plus Jakarta Sans","Noto Sans",sans-serif;'>

--- a/script.js
+++ b/script.js
@@ -142,13 +142,48 @@ function renderList(containerId, items, page=1, perPage=6) {
   const pageItems = items.slice(start,start+perPage);
   pageItems.forEach(item => {
     const div = document.createElement("div");
-    div.className = "w-40 text-center";
+    div.className = "w-40 text-center flex flex-col";
+
+    const img = document.createElement("img");
+    img.src = item.image;
+    img.className = "rounded-lg w-full mb-2";
+    div.appendChild(img);
+
+    const title = document.createElement("p");
+    title.textContent = item.title;
+    div.appendChild(title);
 
     const desc = item.description || item.desc || "";
-    const description = desc ? `<p class='text-sm mt-1'>${desc}</p>` : "";
+    let descP;
+    if (desc) {
+      descP = document.createElement("p");
+      descP.className = "text-sm mt-1 desc clamp";
+      descP.textContent = desc;
+      div.appendChild(descP);
 
-    div.innerHTML = `<img src="${item.image}" class="rounded-lg w-full mb-2"/><p>${item.title}</p>${description}<button class='save-btn bg-red-500 text-white px-2 py-1 rounded mt-1'>Save</button>`;
-    div.querySelector('.save-btn').onclick = () => saveToWatchlist(item);
+      const moreBtn = document.createElement("button");
+      moreBtn.textContent = "See More";
+      moreBtn.className = "text-xs text-blue-500 mt-1";
+      moreBtn.onclick = () => {
+        descP.classList.toggle("clamp");
+        moreBtn.textContent = descP.classList.contains("clamp") ? "See More" : "See Less";
+      };
+      div.appendChild(moreBtn);
+    }
+
+    if (item.reason) {
+      const reason = document.createElement("p");
+      reason.className = "text-xs mt-1 text-gray-600";
+      reason.textContent = `Reason: ${item.reason}`;
+      div.appendChild(reason);
+    }
+
+    const save = document.createElement("button");
+    save.textContent = "Save";
+    save.className = "save-btn bg-red-500 text-white px-2 py-1 rounded mt-1";
+    save.onclick = () => saveToWatchlist(item);
+    div.appendChild(save);
+
     container.appendChild(div);
   });
   if (items.length > perPage) {
@@ -183,12 +218,32 @@ async function loadWatchlist() {
   snapshot.forEach(doc => {
     const item = doc.data();
     const div = document.createElement("div");
-    div.className = "w-40 text-center";
+    div.className = "w-40 text-center flex flex-col";
+
+    const img = document.createElement("img");
+    img.src = item.image;
+    img.className = "rounded-lg w-full mb-2";
+    div.appendChild(img);
+
+    const title = document.createElement("p");
+    title.textContent = item.title;
+    div.appendChild(title);
 
     const desc = item.description || item.desc || "";
-    const description = desc ? `<p class='text-sm mt-1'>${desc}</p>` : "";
+    if (desc) {
+      const p = document.createElement("p");
+      p.className = "text-sm mt-1 desc clamp";
+      p.textContent = desc;
+      div.appendChild(p);
+    }
 
-    div.innerHTML = `<img src="${item.image}" class="rounded-lg w-full mb-2"/><p>${item.title}</p>${description}`;
+    if (item.reason) {
+      const reason = document.createElement("p");
+      reason.className = "text-xs mt-1 text-gray-600";
+      reason.textContent = `Reason: ${item.reason}`;
+      div.appendChild(reason);
+    }
+
     container.appendChild(div);
   });
 }

--- a/watchlist.html
+++ b/watchlist.html
@@ -12,6 +12,15 @@
   <script src="https://www.gstatic.com/firebasejs/10.12.0/firebase-auth-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/10.12.0/firebase-firestore-compat.js"></script>
   <script defer src="script.js"></script>
+  <style>
+    .desc.clamp {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      display: -webkit-box;
+      -webkit-line-clamp: 3;
+      -webkit-box-orient: vertical;
+    }
+  </style>
 </head>
 <body class="bg-[#fcf8f8]" style='font-family:"Plus Jakarta Sans","Noto Sans",sans-serif;'>
 


### PR DESCRIPTION
## Summary
- maintain consistent card sizing by clamping description text
- add "See More" toggle for descriptions
- display API provided `reason` field
- apply the same style on the watchlist page

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_6889d639cbb08321a175f2c9e56453b3