### PR TITLE
Update watchlist loader to use auth user parameter

### DIFF
--- a/script.js
+++ b/script.js
@@ -223,11 +223,8 @@ async function saveToWatchlist(item) {
   alert(`${item.title} saved!`);
 }
 
-async function loadWatchlist() {
-  if (!currentUser) {
-    console.log("[debug] loadWatchlist called without user");
-    return;
-  }
+async function loadWatchlist(user) {
+  currentUser = user || currentUser;
   console.log("Loading watchlist for user", currentUser.uid);
   const container = document.getElementById("watchlistContainer");
   container.innerHTML = "Loading...";
@@ -267,4 +264,4 @@ async function loadWatchlist() {
     container.appendChild(div);
   });
 }
-if (document.getElementById("watchlistContainer")) auth.onAuthStateChanged(() => loadWatchlist());
+if (document.getElementById("watchlistContainer")) auth.onAuthStateChanged(user => loadWatchlist(user));


### PR DESCRIPTION
## Summary
- update auth state watcher for watchlist page to pass the user object
- let `loadWatchlist` accept the user parameter and assign `currentUser`
- remove early return since the current user is now set via the watcher

## Testing
- `node -c script.js && echo "syntax ok"`
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_688a637ddd808321ad7a088b43b10a66