### PR TITLE
Fix watchlist loader for logged-out users

### DIFF
--- a/script.js
+++ b/script.js
@@ -117,7 +117,8 @@ function renderSearchResults(results) {
 
 // Fetch recommendations with spinner
 const recommendBtn = document.getElementById("recommendButton");
-recommendBtn.addEventListener("click", async () => {
+if (recommendBtn) {
+  recommendBtn.addEventListener("click", async () => {
   const criteria = document.getElementById("criteriaSelect").value;
   const emojis = [...document.querySelectorAll('.emoji-btn.active')].map(e => e.textContent).join(',');
   const context = `${document.getElementById("toggleFriends").checked ? 'with friends' : (document.getElementById("toggleAlone").checked ? 'alone' : '')}, ${document.getElementById("toggleLong").checked ? 'long session' : (document.getElementById("toggleShort").checked ? 'short session' : '')}`;
@@ -133,7 +134,10 @@ recommendBtn.addEventListener("click", async () => {
     console.error("Recommendation fetch failed", e);
     document.getElementById("movieList").innerHTML = `<p class='text-red-500'>Failed to load recommendations</p>`;
   }
-});
+  });
+} else {
+  console.log("[debug] recommendButton not found - skipping recommendation setup");
+}
 
 // Render results with pagination and watchlist
 function renderResults(data) {
@@ -223,13 +227,14 @@ async function saveToWatchlist(item) {
   alert(`${item.title} saved!`);
 }
 
-async function loadWatchlist() {
+async function loadWatchlist(user) {
+  currentUser = user || currentUser;
+  const container = document.getElementById("watchlistContainer");
   if (!currentUser) {
-    console.log("[debug] loadWatchlist called without user");
+    container.innerHTML = "<p class='text-sm'>Login to view your watchlist.</p>";
     return;
   }
   console.log("Loading watchlist for user", currentUser.uid);
-  const container = document.getElementById("watchlistContainer");
   container.innerHTML = "Loading...";
   const snapshot = await db.collection("users").doc(currentUser.uid).collection("watchlist").get();
   container.innerHTML = "";
@@ -267,4 +272,4 @@ async function loadWatchlist() {
     container.appendChild(div);
   });
 }
-if (document.getElementById("watchlistContainer")) auth.onAuthStateChanged(() => loadWatchlist());
+if (document.getElementById("watchlistContainer")) auth.onAuthStateChanged(user => loadWatchlist(user));


### PR DESCRIPTION
## Summary
- avoid crashing when watchlist loads without a signed-in user

## Testing
- `node -c script.js && echo 'syntax ok'`
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_688a637ddd808321ad7a088b43b10a66